### PR TITLE
Pin a tag of pattern-library

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
             API_URI: http://web:1080
             APP_SECRET:
     pattern-library:
-        image: ${DOCKER_NAMESPACE}/pattern-library:${REVISION_PATTERN_LIBRARY:-latest}
+        image: ${DOCKER_NAMESPACE}/pattern-library:${REVISION_PATTERN_LIBRARY:-b3729776e04ae9213d7ccc35ee966bd53e031801}
     web:
         image: nginx:1.15.2-alpine
         volumes:


### PR DESCRIPTION
`latest` is not re-pulled by docker-compose, hence it's easier to pin a specific immutable tag.