### PR TITLE
Pattern library default version

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -5,4 +5,5 @@ PUBLIC_PORT=8080
 REVISION_BROWSER=40072ba33ed17d1cbcb5e24d2b83b03accace5b0
 # TODO: put this to latest as a default, when `latest` is available
 REVISION_DUMMY_API=f0fdadac9163b26232f7b24cc77656ce1417c20d
-REVISION_PATTERN_LIBRARY=latest
+# TODO: put this to latest as a default, when `latest` is available
+REVISION_PATTERN_LIBRARY=0b0336f50ba7385a9c111c1b80a6dc4ba8ac6d38

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
             API_URI: http://web:1080
             APP_SECRET:
     pattern-library:
-        image: ${DOCKER_NAMESPACE}/pattern-library:${REVISION_PATTERN_LIBRARY:-b3729776e04ae9213d7ccc35ee966bd53e031801}
+        image: ${DOCKER_NAMESPACE}/pattern-library:${REVISION_PATTERN_LIBRARY}
     web:
         image: nginx:1.15.2-alpine
         volumes:


### PR DESCRIPTION
Currently the `latest` tag is manually updated, and is out of date. Here we pin a more recent version, which is used as a default when you check out this repository.

Once you start using this repository into an actual server, the defaults stop being used and the versions evolve as part of each deploy from [`environments`](https://github.com/libero/environments/).