### PR TITLE
Demonstrate secret mounting in placeholder service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.env
+/secrets/*.secret

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ services: docker
 
 install:
     - ln -s .env.dist .env
-    - docker-compose --version
     - travis_retry docker-compose pull
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ services: docker
 
 install:
     - ln -s .env.dist .env
+    - docker-compose --version
     - travis_retry docker-compose pull
 
 before_script:

--- a/docker-compose.secrets.yml
+++ b/docker-compose.secrets.yml
@@ -2,6 +2,7 @@ version: '3.6'
 
 services:
     elife-style-content-adapter:
+        command: sh -c 'mkdir -p ~/.aws && ln -sf /run/secrets/elife-style-content-adapter-aws-credentials ~/.aws/credentials && ls -l ~/.aws/credentials && sleep 3600'
         secrets:
             # mounted at /run/secrets/elife-style-content-adapter-aws-credentials
             - elife-style-content-adapter-aws-credentials

--- a/docker-compose.secrets.yml
+++ b/docker-compose.secrets.yml
@@ -1,4 +1,4 @@
-version: '3.6'
+version: '3.4'
 
 services:
     elife-style-content-adapter:

--- a/docker-compose.secrets.yml
+++ b/docker-compose.secrets.yml
@@ -1,0 +1,11 @@
+version: '3.6'
+
+services:
+    elife-style-content-adapter:
+        secrets:
+            # mounted at /run/secrets/elife-style-content-adapter-aws-credentials
+            - elife-style-content-adapter-aws-credentials
+
+secrets:
+    elife-style-content-adapter-aws-credentials:
+        file: ./secrets/elife-style-content-adapter-aws-credentials.secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.6'
+version: '3.4'
 
 services:
     # placeholder service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     # placeholder service
     elife-style-content-adapter:
         image: busybox
-        command: sh -c 'ls -l /run/secrets/elife-style-content-adapter-aws-credentials && sleep 3600'
+        command: sleep 3600
         restart: always
     dummy-api_fpm:
         image: ${DOCKER_NAMESPACE}/dummy-api:${REVISION_DUMMY_API}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,7 @@ services:
     # placeholder service
     elife-style-content-adapter:
         image: busybox
-        command: sleep 3600
-        secrets:
-            # mounted at /run/secrets/elife-style-content-adapter-aws-credentials
-            - elife-style-content-adapter-aws-credentials
+        command: sh -c 'ls -l /run/secrets/elife-style-content-adapter-aws-credentials && sleep 3600'
         restart: always
     dummy-api_fpm:
         image: ${DOCKER_NAMESPACE}/dummy-api:${REVISION_DUMMY_API}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,14 @@
-version: '3'
+version: '3.6'
 
 services:
+    # placeholder service
+    elife-style-content-adapter:
+        image: busybox
+        command: sleep 3600
+        secrets:
+            # mounted at /run/secrets/elife-style-content-adapter-aws-credentials
+            - elife-style-content-adapter-aws-credentials
+        restart: always
     dummy-api_fpm:
         image: ${DOCKER_NAMESPACE}/dummy-api:${REVISION_DUMMY_API}
         volumes:


### PR DESCRIPTION
Secrets can be separated from environment variables, as a file to read is easier to segregate than a container-wide environment variable that can be [easily accessed by subprocesses or dumped in logs](https://stackoverflow.com/questions/55620043/is-there-any-security-advantage-to-mounting-secrets-as-a-file-instead-of-passing).

This is a `docker-compose` configuration, but the [Kubernetes equivalent](https://kubernetes.io/docs/concepts/configuration/secret/) doesn't differ in how the secrets are consumed by the container (files or environment variables allowed); only in how they are created.