### PR TITLE
Add proxying of jats-ingester_webserver

### DIFF
--- a/.docker/public-nginx.conf
+++ b/.docker/public-nginx.conf
@@ -69,3 +69,12 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
+
+server {
+    server_name ~^.+--jats-ingester\.libero\.pub$;
+    listen 80;
+
+    location / {
+        proxy_pass http://jats-ingester_webserver:8080;
+    }
+}

--- a/.docker/public-nginx.conf
+++ b/.docker/public-nginx.conf
@@ -72,7 +72,7 @@ server {
 
 server {
     server_name ~^.+--jats-ingester\.libero\.pub$;
-    listen 80;
+    listen 0.0.0.0:8085;
 
     location / {
         proxy_pass http://jats-ingester_webserver:8080;

--- a/.env.dist
+++ b/.env.dist
@@ -5,6 +5,7 @@ PUBLIC_PORT_GATEWAY=8081
 PUBLIC_PORT_PATTERN_LIBRARY=8082
 PUBLIC_PORT_DUMMY_API=8083
 PUBLIC_PORT_S3=8084
+PUBLIC_PORT_JATS_INGESTER=8085
 # TODO: put this to latest as a default, when `latest` is available
 REVISION_BROWSER=7b392639c7ee554bc2b8f1ad0e099b8c68c4381a
 # TODO: put this to latest as a default, when `latest` is available

--- a/.env.dist
+++ b/.env.dist
@@ -5,7 +5,6 @@ PUBLIC_PORT_GATEWAY=8081
 PUBLIC_PORT_PATTERN_LIBRARY=8082
 PUBLIC_PORT_DUMMY_API=8083
 PUBLIC_PORT_S3=8084
-PUBLIC_PORT_JATS_INGESTER=8085
 # TODO: put this to latest as a default, when `latest` is available
 REVISION_BROWSER=7b392639c7ee554bc2b8f1ad0e099b8c68c4381a
 # TODO: put this to latest as a default, when `latest` is available

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,6 @@ services:
         command: sh -c "airflow upgradedb && airflow webserver -p 8080"
         volumes:
             - .docker/jats-ingester/airflow.cfg:/airflow/airflow.cfg
-        ports:
-            - ${PUBLIC_PORT_JATS_INGESTER}:8080
         healthcheck:
             test: ["CMD-SHELL", "python ./scripts/airflow_webserver_healthcheck.py"]
         restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,6 +183,7 @@ services:
             - ${PUBLIC_PORT_BROWSER}:80
             - ${PUBLIC_PORT_PATTERN_LIBRARY}:8082
             - ${PUBLIC_PORT_DUMMY_API}:8083
+            - ${PUBLIC_PORT_JATS_INGESTER}:8085
         healthcheck:
             test: ["CMD", "nc", "-z", "localhost", "80"]
             interval: 5s


### PR DESCRIPTION
From the outside, the webserver can still be reached at port 8085 so not much changes. However, like for all others there is a consistent proxying from a single nginx rather than every container exposing its own ports. This helps with centralizing configurations like the upcoming HTTPS one in a single place.