### PR TITLE
Wait for yellow elasticsearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,7 +135,7 @@ services:
             discovery.type: single-node
             ES_JAVA_OPTS: -Xmx256m -Xms256m
         healthcheck:
-            test: ["CMD", "curl", "localhost:9200/_cluster/health?wait_for_status=green"]
+            test: ["CMD", "curl", "localhost:9200/_cluster/health?wait_for_status=yellow"]
     search_wsgi:
         image: ${DOCKER_NAMESPACE}/search:${REVISION_SEARCH}
         command: uwsgi --ini=uwsgi.ini


### PR DESCRIPTION
Follow-up to https://github.com/libero/libero/issues/175

Unless replication is setup, the cluster status will only go from red to yellow, but not to green. Since everything runs on a single machine, it wouldn't make much sense to setup two containers replicating data.