### PR TITLE
Disable ingestion of S3 images in content-store

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,8 @@ services:
             DEFAULT_LOCALE:
             SERVICE_NAME: scholarly-articles
             DATABASE_URL: pgsql://postgres:@scholarly-articles_postgres:5432/postgres
-            ASSETS_ORIGIN_WHITELIST: ^(https://iiif\.elifesciences\.org/|https://unstable-jats-ingester-expanded\.s3\.amazonaws\.com/)
+            #ASSETS_ORIGIN_WHITELIST: ^(https://iiif\.elifesciences\.org/|https://unstable-jats-ingester-expanded\.s3\.amazonaws\.com/)
+            ASSETS_ORIGIN_WHITELIST: ^https://iiif\.elifesciences\.org/
         restart: always
         depends_on:
             - scholarly-articles_postgres


### PR DESCRIPTION
The `Content-Type: binary/octet-stream` is too generic and doesn't allow `content-store` to treat the file as an image, so disabling for now and relying on serving the `expanded` bucket object directly.