### PR TITLE
Revert "Disable ingestion of S3 images in content-store (#49)"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,8 +113,7 @@ services:
             DEFAULT_LOCALE:
             SERVICE_NAME: scholarly-articles
             DATABASE_URL: pgsql://postgres:@scholarly-articles_postgres:5432/postgres
-            #ASSETS_ORIGIN_WHITELIST: ^(https://iiif\.elifesciences\.org/|https://unstable-jats-ingester-expanded\.s3\.amazonaws\.com/)
-            ASSETS_ORIGIN_WHITELIST: ^https://iiif\.elifesciences\.org/
+            ASSETS_ORIGIN_WHITELIST: ^(https://iiif\.elifesciences\.org/|https://unstable-jats-ingester-expanded\.s3\.amazonaws\.com/)
         restart: always
         depends_on:
             - scholarly-articles_postgres


### PR DESCRIPTION
This reverts commit 703f1d46b2324eec6f38b1786b6ccd9f7711ce51.

Uses https://github.com/libero/content-store/pull/14