### PR TITLE
Update `depends_on`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,11 +171,8 @@ services:
             interval: 5s
         restart: always
         depends_on:
-            - blog-articles_fpm
             - blog-articles_web
-            - scholarly-articles_fpm
             - scholarly-articles_web
-            - search_wsgi
             - search_web
     web:
         image: nginx:1.15.2-alpine
@@ -190,8 +187,10 @@ services:
             interval: 5s
         restart: always
         depends_on:
+            - api-gateway
             - browser_fpm
             - dummy-api_fpm
+            - jats-ingester_webserver
             - pattern-library
 
 volumes:


### PR DESCRIPTION
Discovered in https://github.com/libero/libero/issues/191

Race condition on startup may prevent the nginx in `web` from seeing the other container's hostnames.