### PR TITLE
update jats ingester parallelism settings

### DIFF
--- a/.docker/jats-ingester/airflow.cfg
+++ b/.docker/jats-ingester/airflow.cfg
@@ -110,10 +110,12 @@ sql_alchemy_schema =
 # The amount of parallelism as a setting to the executor. This defines
 # the max number of task instances that should run simultaneously
 # on this airflow installation
-parallelism = 32
+# parallelism = 32
+parallelism = 8
 
 # The number of task instances allowed to run concurrently by the scheduler
-dag_concurrency = 16
+# dag_concurrency = 16
+dag_concurrency = 4
 
 # Are DAGs paused by default at creation
 # dags_are_paused_at_creation = True
@@ -124,7 +126,8 @@ dags_are_paused_at_creation = False
 non_pooled_task_slot_count = 128
 
 # The maximum number of active DAG runs per DAG
-max_active_runs_per_dag = 16
+# max_active_runs_per_dag = 16
+max_active_runs_per_dag = 4
 
 # Whether to load the examples that ship with Airflow. It's good to
 # get started, but you probably want to set this to False in a production
@@ -295,7 +298,8 @@ dag_default_view = tree
 
 # Default DAG orientation. Valid values are:
 # LR (Left->Right), TB (Top->Bottom), RL (Right->Left), BT (Bottom->Top)
-dag_orientation = LR
+# dag_orientation = LR
+dag_orientation = TB
 
 # Puts the webserver in demonstration mode; blurs the names of Operators for
 # privacy.


### PR DESCRIPTION
These setting changes should limit the number of articles being processed at a given moment and make better use of the hardware available.