### PR TITLE
Unlock elasticsearch writes on start up if max disk usage threshold reached

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,6 +150,7 @@ services:
             - data-search:/usr/share/elasticsearch/data
         environment:
             discovery.type: single-node
+            index.blocks.read_only_allow_delete: null
             ES_JAVA_OPTS: -Xmx256m -Xms256m
         healthcheck:
             test: ["CMD", "curl", "localhost:9200/_cluster/health?wait_for_status=yellow"]


### PR DESCRIPTION
Recently, libero demo environment hit 100% disk usage. When services were restarted disk space was freed, however, elasticsearch continued to not permit writes, which in turn would fail deployments with fixes.

After reading [elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/disk-allocator.html) and [this post](https://techoverflow.net/2019/04/17/how-to-disable-elasticsearch-disk-quota-watermark/) I was able to rectify the issue and decided to add this setting as a default, i.e. unlocking elasticsearch on startup.