### PR TITLE
Add log rotation to Elasticsearch

### DIFF
--- a/.docker/search/log4j2.properties
+++ b/.docker/search/log4j2.properties
@@ -1,0 +1,51 @@
+status = error
+
+# log action execution errors for easier debugging
+logger.action.name = org.elasticsearch.action
+logger.action.level = debug
+
+appender.rolling.type = Console
+appender.rolling.name = rolling
+appender.rolling.layout.type = ESJsonLayout
+appender.rolling.layout.type_name = server
+
+rootLogger.level = info
+rootLogger.appenderRef.rolling.ref = rolling
+
+appender.deprecation_rolling.type = Console
+appender.deprecation_rolling.name = deprecation_rolling
+appender.deprecation_rolling.layout.type = ESJsonLayout
+appender.deprecation_rolling.layout.type_name = deprecation
+
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.action.type = Delete
+appender.rolling.strategy.action.basepath = ${sys:es.logs.base_path}
+appender.rolling.strategy.action.condition.type = IfFileName
+appender.rolling.strategy.action.condition.glob = ${sys:es.logs.cluster_name}-*
+appender.rolling.strategy.action.condition.nested_condition.type = IfLastModified
+appender.rolling.strategy.action.condition.nested_condition.age = 30D
+
+logger.deprecation.name = org.elasticsearch.deprecation
+logger.deprecation.level = warn
+logger.deprecation.appenderRef.deprecation_rolling.ref = deprecation_rolling
+logger.deprecation.additivity = false
+
+appender.index_search_slowlog_rolling.type = Console
+appender.index_search_slowlog_rolling.name = index_search_slowlog_rolling
+appender.index_search_slowlog_rolling.layout.type = ESJsonLayout
+appender.index_search_slowlog_rolling.layout.type_name = index_search_slowlog
+
+logger.index_search_slowlog_rolling.name = index.search.slowlog
+logger.index_search_slowlog_rolling.level = trace
+logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref = index_search_slowlog_rolling
+logger.index_search_slowlog_rolling.additivity = false
+
+appender.index_indexing_slowlog_rolling.type = Console
+appender.index_indexing_slowlog_rolling.name = index_indexing_slowlog_rolling
+appender.index_indexing_slowlog_rolling.layout.type = ESJsonLayout
+appender.index_indexing_slowlog_rolling.layout.type_name = index_indexing_slowlog
+
+logger.index_indexing_slowlog.name = index.indexing.slowlog.index
+logger.index_indexing_slowlog.level = trace
+logger.index_indexing_slowlog.appenderRef.index_indexing_slowlog_rolling.ref = index_indexing_slowlog_rolling
+logger.index_indexing_slowlog.additivity = false

--- a/.docker/search/log4j2.properties
+++ b/.docker/search/log4j2.properties
@@ -1,3 +1,6 @@
+# The properties below were copied from the original file found in the
+# elasticsearch docker image /usr/share/elasticsearch/config/log4j2.properties
+
 status = error
 
 # log action execution errors for easier debugging
@@ -17,6 +20,7 @@ appender.deprecation_rolling.name = deprecation_rolling
 appender.deprecation_rolling.layout.type = ESJsonLayout
 appender.deprecation_rolling.layout.type_name = deprecation
 
+# This section was added for use within Libero Publisher
 appender.rolling.strategy.type = DefaultRolloverStrategy
 appender.rolling.strategy.action.type = Delete
 appender.rolling.strategy.action.basepath = ${sys:es.logs.base_path}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,7 +147,9 @@ services:
     search_elasticsearch:
         image: docker.elastic.co/elasticsearch/elasticsearch:7.1.1
         volumes:
+            - .docker/search/log4j2.properties:/usr/share/elasticsearch/config/log4j2.properties
             - data-search:/usr/share/elasticsearch/data
+            - data-search-logs:/usr/share/elasticsearch/logs
         environment:
             discovery.type: single-node
             index.blocks.read_only_allow_delete: null
@@ -215,6 +217,8 @@ volumes:
     data-scholarly-articles:
         external: true
     data-search:
+        external: true
+    data-search-logs:
         external: true
     data-s3:
         external: true


### PR DESCRIPTION
In reference to https://github.com/libero/publisher/issues/254

- Add elasticsearch logs volume
- Add log rotation policy to log4j2.properties file (copied the current settings from elasticsearch and added the `appender.rolling.strategy` section)