### PR TITLE
add aws config file to jats-ingester

### DIFF
--- a/.docker/jats-ingester/aws_config
+++ b/.docker/jats-ingester/aws_config
@@ -1,0 +1,1 @@
+[default]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
         command: sh -c "airflow upgradedb && airflow webserver -p 8080"
         volumes:
             - .docker/jats-ingester/airflow.cfg:/airflow/airflow.cfg
+            - .docker/jats-ingester/airflow.cfg:/airflow/.aws/config
         environment:
             ENVIRONMENT_NAME: ${ENVIRONMENT_NAME}
         healthcheck:
@@ -33,6 +34,7 @@ services:
         command: sh -c "airflow scheduler"
         volumes:
             - .docker/jats-ingester/airflow.cfg:/airflow/airflow.cfg
+            - .docker/jats-ingester/airflow.cfg:/airflow/.aws/config
         environment:
             ENVIRONMENT_NAME: ${ENVIRONMENT_NAME}
         restart: always
@@ -44,6 +46,7 @@ services:
         command: sh -c "airflow worker"
         volumes:
             - .docker/jats-ingester/airflow.cfg:/airflow/airflow.cfg
+            - .docker/jats-ingester/airflow.cfg:/airflow/.aws/config
         environment:
             ENVIRONMENT_NAME: ${ENVIRONMENT_NAME}
         healthcheck:


### PR DESCRIPTION
The following error was found after deploying recent changes to `jats-ingester` in the unstable environment so that node.js could be used to run tasks in Apache Airflow.

```
Error: ENOENT: no such file or directory, open '/airflow/.aws/config
```

- adds aws config file to `jats-ingester`. No default settings applied.